### PR TITLE
Strip shlib during pkg installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 
 FROM alpine:3.10.3
 
+ENV _R_SHLIB_STRIP_=true
+
 RUN apk update &&                                                        \
     apk add gcc musl-dev gfortran g++ zlib-dev bzip2-dev xz-dev pcre-dev \
     curl-dev make perl &&                                                \


### PR DESCRIPTION
This gives smaller footprint for subsequent pkg installation "for free". See details [here](https://github.com/wch/r-source/blob/06185bd431beb9b6e0883193273d1779ef2c6a2c/src/library/tools/R/install.R#L249) and 
[here](https://github.com/wch/r-source/blob/06185bd431beb9b6e0883193273d1779ef2c6a2c/src/library/tools/R/install.R#L547).