### PR TITLE
Added tidyverse example

### DIFF
--- a/examples/tidyverse/Dockerfile
+++ b/examples/tidyverse/Dockerfile
@@ -1,0 +1,8 @@
+
+FROM rhub/r-minimal
+
+RUN installr -d \
+   -t "R-dev file automake autoconf linux-headers" \
+   -a "libxml2-dev icu-libs" `# needed for xml2 and stringr`  \
+   tidyverse/readxl `# CRAN version does not compile on alpine` \
+   tidyverse

--- a/examples/tidyverse/Dockerfile
+++ b/examples/tidyverse/Dockerfile
@@ -2,7 +2,7 @@
 FROM rhub/r-minimal
 
 RUN installr -d \
-   -t "R-dev file automake autoconf linux-headers" \
-   -a "libxml2-dev icu-libs" `# needed for xml2 and stringr`  \
+   -t "R-dev file automake autoconf linux-headers libxml2-dev" \
+   -a "libxml2 icu-libs" `# needed for xml2 and stringr`  \
    tidyverse/readxl `# CRAN version (<=1.3.1) does not compile on alpine` \
    tidyverse

--- a/examples/tidyverse/Dockerfile
+++ b/examples/tidyverse/Dockerfile
@@ -4,5 +4,5 @@ FROM rhub/r-minimal
 RUN installr -d \
    -t "R-dev file automake autoconf linux-headers" \
    -a "libxml2-dev icu-libs" `# needed for xml2 and stringr`  \
-   tidyverse/readxl `# CRAN version does not compile on alpine` \
+   tidyverse/readxl `# CRAN version (<=1.3.1) does not compile on alpine` \
    tidyverse


### PR DESCRIPTION
Added an example for building a tidyverse image. 
Note that it uses the latest github version of readxl, since the CRAN version (1.3.1) is not compatible with alpine.