### PR TITLE
Get the magor version in the URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ RUN apk update &&                                                        \
     elif [[ "$R_VERSION" == "patched" ]]; then                           \
         wget https://stat.ethz.ch/R/daily/R-patched.tar.gz;              \
     else                                                                 \
-        wget https://cran.r-project.org/src/base/R-3/R-${R_VERSION}.tar.gz || \
-        wget https://cran.r-project.org/src/base/R-4/R-${R_VERSION}.tar.gz; \
+        wget https://cran.r-project.org/src/base/R-${R_VERSION%%.*}/R-${R_VERSION}.tar.gz; \
     fi &&                                                                \
     tar xzf R-${R_VERSION}.tar.gz &&                                     \
 ##


### PR DESCRIPTION
No need to check different R version with wget.
See the bash docs for more details about string manipultation: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html