### PR TITLE
Add set -e call to installr

### DIFF
--- a/installr
+++ b/installr
@@ -1,4 +1,5 @@
 #! /usr/bin/env sh
+set -e
 
 usage() {
     echo "Usage: $0 [ -c | -d ] [ -a pkgs ] [ -t pkgs ] [ -r ] [ -p ] REMOTES ..."


### PR DESCRIPTION
Resolves #38 by adding `set -e` under shebang in installr.