### PR TITLE
fix: explicit length check for args

### DIFF
--- a/installr
+++ b/installr
@@ -21,7 +21,7 @@ usage() {
 }
 
 error() {
-    >&2 echo $1
+    echo $1 >&2
     exit 2
 }
 
@@ -61,7 +61,7 @@ echo --------------------------------------
 echo "Installing pak (if needed)"
 Rscript -e 'if (! requireNamespace("pak", quietly=TRUE)) install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/devel/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))'
 
-if [[ -z "$@" ]]; then
+if [[ $# -eq 0 ]]; then
     echo
     echo --------------------------------------
     echo No R packages to install


### PR DESCRIPTION
Explicit length check for args preventing unknown operand message when installing multiple packages