### PR TITLE
feat: example for rJava

### DIFF
--- a/examples/rJava/Dockerfile
+++ b/examples/rJava/Dockerfile
@@ -1,0 +1,5 @@
+FROM rhub/r-minimal
+
+RUN installr -c -p -a "openjdk17 pcre2 pcre2-dev libbz2 bzip2-dev xz-libs xz-dev" \
+    && R CMD javareconf \
+    && installr -d -t "pcre2-dev bzip2-dev xz-dev" rJava

--- a/examples/rJava/Dockerfile
+++ b/examples/rJava/Dockerfile
@@ -1,5 +1,7 @@
 FROM rhub/r-minimal
 
-RUN installr -c -p -a "openjdk17 pcre2 pcre2-dev libbz2 bzip2-dev xz-libs xz-dev" \
+RUN installr -c -p -a openjdk17 \
     && R CMD javareconf \
-    && installr -d -t "pcre2-dev bzip2-dev xz-dev" rJava
+    && installr -d \
+    -t "make pcre2-dev bzip2-dev xz-dev" \
+    -a "pcre2 libbz2 xz-libs" rJava


### PR DESCRIPTION
Example for rJava, usefull as a base image for installing RWeka or other Java packages. Based on openjdk-17 LTS.