### PR TITLE
shiny example: No need to install system libraries

### DIFF
--- a/examples/shiny/Dockerfile
+++ b/examples/shiny/Dockerfile
@@ -1,13 +1,6 @@
 
 FROM rhub/r-minimal
 
-RUN apk add --no-cache --update-cache \
-        --repository http://nl.alpinelinux.org/alpine/v3.11/main \
-        autoconf=2.69-r2 \
-        automake=1.16.1-r0 && \
-    # repeat autoconf and automake (under `-t`)
-    # to (auto)remove them after installation
-    installr -d \
-        -t "libsodium-dev curl-dev linux-headers autoconf automake" \
-        -a libsodium \
+RUN installr -d \
+        -t "zlib-dev" \
         shiny


### PR DESCRIPTION
It seems like it is working fine installing `shiny:1.8.0` on `rhub/r-minimal:4.3.2` without installing the libraries `libsodium-dev`, `curl-dev`, `linux-headers`, `autoconf`, `automake` and `libsodium`. Only `zlib-dev` is needed. 

`zlib-dev` was installed earlier because [`curl-dev`](https://pkgs.alpinelinux.org/package/edge/main/x86/curl-dev) depends on it.

Related to #77 